### PR TITLE
Add USD price prediction example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # colombianhearmap
 Mapa de calor Homicidios en Colombia
+
+## Predicción del precio del dólar
+
+Se añadió el script `usd_prediction.py` que descarga datos históricos de la tasa de cambio USD/EUR desde la API pública de la Reserva Federal (FRED) y realiza pronósticos de los próximos 7 días mediante dos métodos populares:
+
+1. ARIMA (implementado con `statsmodels`).
+2. Prophet (implementado con `prophet`).
+
+### Requisitos
+
+```bash
+pip install pandas numpy statsmodels prophet requests
+```
+
+### Uso
+
+Ejecutar el script directamente:
+
+```bash
+python usd_prediction.py
+```
+
+El programa mostrará los últimos datos descargados y los pronósticos generados por ambos métodos.

--- a/usd_prediction.py
+++ b/usd_prediction.py
@@ -1,0 +1,48 @@
+import pandas as pd
+import requests
+from io import StringIO
+from statsmodels.tsa.arima.model import ARIMA
+from prophet import Prophet
+
+
+def download_exchange_rate(series_id: str = "DEXUSEU") -> pd.DataFrame:
+    url = f"https://fred.stlouisfed.org/graph/fredgraph.csv?id={series_id}"
+    resp = requests.get(url)
+    resp.raise_for_status()
+    data = pd.read_csv(StringIO(resp.text))
+    data['observation_date'] = pd.to_datetime(data['observation_date'])
+    data.rename(columns={'observation_date': 'ds', series_id: 'y'}, inplace=True)
+    data.dropna(inplace=True)
+    return data
+
+
+def predict_arima(df: pd.DataFrame, steps: int = 7) -> pd.Series:
+    model = ARIMA(df['y'], order=(5, 1, 0))
+    fitted = model.fit()
+    forecast = fitted.forecast(steps=steps)
+    return forecast
+
+
+def predict_prophet(df: pd.DataFrame, periods: int = 7) -> pd.DataFrame:
+    model = Prophet()
+    model.fit(df)
+    future = model.make_future_dataframe(periods=periods)
+    forecast = model.predict(future)
+    return forecast[['ds', 'yhat']].tail(periods)
+
+
+def main():
+    df = download_exchange_rate()
+    print("Datos cargados:\n", df.tail())
+
+    print("\nPronóstico ARIMA (siguientes 7 días):")
+    arima_forecast = predict_arima(df)
+    print(arima_forecast)
+
+    print("\nPronóstico Prophet (siguientes 7 días):")
+    prophet_forecast = predict_prophet(df)
+    print(prophet_forecast)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `usd_prediction.py` with ARIMA and Prophet forecasts
- update README with instructions for the new script

## Testing
- `python usd_prediction.py`

------
https://chatgpt.com/codex/tasks/task_e_685f01827fe08323a23d955c51fbd14a